### PR TITLE
bump: anon to browser-extension, sdk 0.7.0, web-link 0.6.0, actions 0.2.0

### DIFF
--- a/connect-react/package.json
+++ b/connect-react/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@anon/sdk-web-link-typescript": "^0.5.1",
+    "@anon/sdk-web-link-typescript": "^0.6.0",
     "@playwright/test": "^1.44.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",

--- a/connect-react/yarn.lock
+++ b/connect-react/yarn.lock
@@ -20,17 +20,17 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@anon/link-types@^0.5.1":
-  version "0.5.1"
-  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/link-types/-/0.5.1/link-types-0.5.1.tgz#79c6017114df2d31ade37af2cf33d768bc017a8c"
-  integrity sha512-YrGBiDYwX6qBiJoN64iJrW57hd3R8YgzEQw5OSWCyiGaKZHWTWXgNIEdY/6+MGACiz6FY/o3fiJgbV1UmmCqlA==
+"@anon/link-types@^0.6.0":
+  version "0.6.0"
+  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/link-types/-/0.6.0/link-types-0.6.0.tgz#0f3e7de55a8882edc13da708b912b5d072b95961"
+  integrity sha512-Nn3GlPnSAWdXkQdORmcagL803hk4madWoDF1nljk/zT0CCcinDt4Oih7YHLMysfJ6qORuPRwftBLiDXSguA9FA==
 
-"@anon/sdk-web-link-typescript@^0.5.1":
-  version "0.5.1"
-  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/sdk-web-link-typescript/-/0.5.1/sdk-web-link-typescript-0.5.1.tgz#9b2ea9b9ae94767de1e57af55a63459d3d5741f3"
-  integrity "sha1-my6pua6Udn3h5Xr1WmNFnT1XQfM= sha512-sdkUZAPND9QQDQdMZckwxszxM3H2NIjzSrb8AC7N9ezuESFeet9h1CbyusFlZXyp6yUKT1aC0Rq/O1B/7j6www=="
+"@anon/sdk-web-link-typescript@^0.6.0":
+  version "0.6.0"
+  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/sdk-web-link-typescript/-/0.6.0/sdk-web-link-typescript-0.6.0.tgz#bae8dc53c3176a4088fac79bc12ad429c94742ab"
+  integrity sha512-RATID6KPOqQkk09f3wbXzI1hfx4qWNcTciFU7GyyqcnkVqtejKU7Q+b7yh0BXe/EXYstmZ/eZFdaF7Fh97wIrw==
   dependencies:
-    "@anon/link-types" "^0.5.1"
+    "@anon/link-types" "^0.6.0"
 
 "@apideck/better-ajv-errors@^0.3.1":
   version "0.3.6"

--- a/connect-vue/package.json
+++ b/connect-vue/package.json
@@ -13,7 +13,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
-    "@anon/sdk-web-link-typescript": "^0.5.1",
+    "@anon/sdk-web-link-typescript": "^0.6.0",
     "jose": "^5.2.3",
     "vue": "^3.4.21",
     "vue-router": "^4.3.0"

--- a/connect-vue/yarn.lock
+++ b/connect-vue/yarn.lock
@@ -10,17 +10,17 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@anon/link-types@^0.5.1":
-  version "0.5.1"
-  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/link-types/-/0.5.1/link-types-0.5.1.tgz#79c6017114df2d31ade37af2cf33d768bc017a8c"
-  integrity sha512-YrGBiDYwX6qBiJoN64iJrW57hd3R8YgzEQw5OSWCyiGaKZHWTWXgNIEdY/6+MGACiz6FY/o3fiJgbV1UmmCqlA==
+"@anon/link-types@^0.6.0":
+  version "0.6.0"
+  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/link-types/-/0.6.0/link-types-0.6.0.tgz#0f3e7de55a8882edc13da708b912b5d072b95961"
+  integrity sha512-Nn3GlPnSAWdXkQdORmcagL803hk4madWoDF1nljk/zT0CCcinDt4Oih7YHLMysfJ6qORuPRwftBLiDXSguA9FA==
 
-"@anon/sdk-web-link-typescript@^0.5.1":
-  version "0.5.1"
-  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/sdk-web-link-typescript/-/0.5.1/sdk-web-link-typescript-0.5.1.tgz#9b2ea9b9ae94767de1e57af55a63459d3d5741f3"
-  integrity sha512-sdkUZAPND9QQDQdMZckwxszxM3H2NIjzSrb8AC7N9ezuESFeet9h1CbyusFlZXyp6yUKT1aC0Rq/O1B/7j6www==
+"@anon/sdk-web-link-typescript@^0.6.0":
+  version "0.6.0"
+  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/sdk-web-link-typescript/-/0.6.0/sdk-web-link-typescript-0.6.0.tgz#bae8dc53c3176a4088fac79bc12ad429c94742ab"
+  integrity sha512-RATID6KPOqQkk09f3wbXzI1hfx4qWNcTciFU7GyyqcnkVqtejKU7Q+b7yh0BXe/EXYstmZ/eZFdaF7Fh97wIrw==
   dependencies:
-    "@anon/link-types" "^0.5.1"
+    "@anon/link-types" "^0.6.0"
 
 "@babel/code-frame@^7.23.5", "@babel/code-frame@^7.24.2":
   version "7.24.2"

--- a/link-extension/package.json
+++ b/link-extension/package.json
@@ -10,7 +10,7 @@
     "package": "plasmo package --source-maps"
   },
   "dependencies": {
-    "@anon/sdk-browser-extension": "^0.6.0",
+    "@anon/sdk-browser-extension": "^0.7.0",
     "jose": "^5.2.4",
     "plasmo": "0.88.0",
     "react": "18.2.0",

--- a/link-extension/yarn.lock
+++ b/link-extension/yarn.lock
@@ -10,10 +10,10 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@anon/sdk-browser-extension@^0.6.0":
-  version "0.6.0"
-  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/sdk-browser-extension/-/0.6.0/sdk-browser-extension-0.6.0.tgz#32f9d9f939e56faeaf82e1bea841737fad103a0e"
-  integrity sha512-r91WqfOqhDqTYmbkOBRHzV3HKTA1tRV/QYyHaldPEyAkDDd5WQxC5Q1va/+crE6BXDnI3Z8evkEr5gCT1NPs2A==
+"@anon/sdk-browser-extension@^0.7.0":
+  version "0.7.0"
+  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/sdk-browser-extension/-/0.7.0/sdk-browser-extension-0.7.0.tgz#8b44a02732c8c11b2127a356cbe140330d70e882"
+  integrity sha512-KODL8WaLFKyl0UcxrzIFUCPkT0K+OYB+4GNCzVUHTEzb2Fo70jUibRHE263N2hxAINaXxGFnA8lr/HxlIYcHng==
   dependencies:
     jose "^5.2.1"
 

--- a/run-typescript/package.json
+++ b/run-typescript/package.json
@@ -16,8 +16,8 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "@anon/actions": "^0.1.1",
-    "@anon/sdk-typescript": "^0.6.0",
+    "@anon/actions": "^0.2.0",
+    "@anon/sdk-typescript": "^0.7.0",
     "@playwright/test": "^1.44.1",
     "dotenv": "^16.4.5",
     "node-fetch": "^3.3.2"

--- a/run-typescript/yarn.lock
+++ b/run-typescript/yarn.lock
@@ -2,50 +2,50 @@
 # yarn lockfile v1
 
 
-"@anon/account-types@^0.5.1":
-  version "0.5.1"
-  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/account-types/-/0.5.1/account-types-0.5.1.tgz#c51f1f5deba8412f12d94d22012677c1148ee732"
-  integrity sha512-ynFQnlRf3MLwfgqWFYIL3Jmzw+DRCu+uwpOwfFu4RarTJLBJAZlXX6/PAQA50xouyfujHFBi/8ln4SP6/QESAg==
+"@anon/account-types@^0.6.0":
+  version "0.6.0"
+  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/account-types/-/0.6.0/account-types-0.6.0.tgz#46575b9b6f29dcc63d74a6e9c2e24fcec867c0f8"
+  integrity sha512-88KklyBjZHPhEuozC0L1CpKrAwv8lp4iIERdlRc0Qy2VZ9xCjdFibF7UAYqe7qw+yqdMWCTBwnCjxJqTuYmw8g==
   dependencies:
     zod "^3.22.4"
 
-"@anon/actions@^0.1.1":
-  version "0.1.1"
-  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/actions/-/0.1.1/actions-0.1.1.tgz#e58a9ec73d862b89ad4196cd3448c1f2b50754c2"
-  integrity sha512-TOWXxgHWNarH1aFwHmj6LQU+eRm/RkWGR0voi1a4C5OSXmXHvycBstIzj/KWr0JoXe4Gz9nnx7myuE7VPdCtbg==
+"@anon/actions@^0.2.0":
+  version "0.2.0"
+  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/actions/-/0.2.0/actions-0.2.0.tgz#8c3f03b41bcd89b16c403bb2612fb627e9f1c7df"
+  integrity sha512-F7y2tdcMrOzU4UzW2xuQf7f821POZhXGat0BlWWw7ONF6lnkKV2pe62T26GBZ7Iru19rzMAi55LO36hNvLWTvw==
   dependencies:
     playwright "^1.43.1"
     playwright-extra "^4.3.6"
 
-"@anon/browser@^0.5.1":
-  version "0.5.1"
-  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/browser/-/0.5.1/browser-0.5.1.tgz#99336faf035982c939d19ab0a7baa81aea7b9d76"
-  integrity sha512-dL9Rq3JtCzA1LFIm+BwA/ZXHm4AhgYJ5p31TfNlhh7AjR9LQ64ietcPTKxxQALoTo8ROk6AS7m6z466ArGBiMA==
+"@anon/browser@^0.6.0":
+  version "0.6.0"
+  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/browser/-/0.6.0/browser-0.6.0.tgz#0215af572dd2b14155fe12a3d5d3ef9bc0dcf14a"
+  integrity sha512-yUs1rHbEmscP5vDimu1b5csrxgNnPty7+nKU1EJhNyNpuTZY78f4Rm4ApreTiOzfhlXIdqD11fpBNqc3aMKNew==
   dependencies:
-    "@anon/account-types" "^0.5.1"
-    "@anon/proxy-types" "^0.5.1"
+    "@anon/account-types" "^0.6.0"
+    "@anon/proxy-types" "^0.6.0"
     "@browserbasehq/sdk" "^1.3.1"
     playwright "^1.43.1"
     playwright-extra "^4.3.6"
     puppeteer-extra-plugin-stealth "^2.11.2"
     zod "^3.22.4"
 
-"@anon/proxy-types@^0.5.1":
-  version "0.5.1"
-  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/proxy-types/-/0.5.1/proxy-types-0.5.1.tgz#14d79805cfb816978f24416124ed2e14621e303a"
-  integrity sha512-UEl59kdIhXlhU+9iryfyneVfwal9SVxMCPgt7nAw2oTUz16WsPMbtdwCF7N49/ZUxGy7G6Tgax0SilxsmNd41Q==
+"@anon/proxy-types@^0.6.0":
+  version "0.6.0"
+  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/proxy-types/-/0.6.0/proxy-types-0.6.0.tgz#567387d1fcdfdc5b97cdc69f0d8d4ee136c6f82f"
+  integrity sha512-ZLeQ7j/9BjWLfKJS+5eXesIQfURuwlxv2oU+JcRpD+1tu4h8sRpuOJCRHgRFoySmNTdI3yRQe4b6Azj6XIGUHQ==
   dependencies:
     node-fetch "^3.3.2"
     proxy-agent "^6.4.0"
 
-"@anon/sdk-typescript@^0.6.0":
-  version "0.6.0"
-  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/sdk-typescript/-/0.6.0/sdk-typescript-0.6.0.tgz#55fb5b63e59c9a5097d690709a2bcad2483550f1"
-  integrity sha512-PLhF1ruJF3SzsDallXrqOhB+1nrBPkkclaoVPZ19rVaVhRbBX/Fo9QAvBcIuj+X13rjhLN4rZXleWj+zq6GbTw==
+"@anon/sdk-typescript@^0.7.0":
+  version "0.7.0"
+  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/sdk-typescript/-/0.7.0/sdk-typescript-0.7.0.tgz#73c6f2ef5b9d2a6ac9807d0df1268d455eab2031"
+  integrity sha512-nDCk7mCMDl1JTNixjUSbxrxU4Y3dKSibuTKZfF/kEd005s+EadxXKfwWN/xPSb2YfFckq8Jd1HjcgAIRBgqY5A==
   dependencies:
-    "@anon/account-types" "^0.5.1"
-    "@anon/browser" "^0.5.1"
-    "@anon/proxy-types" "^0.5.1"
+    "@anon/account-types" "^0.6.0"
+    "@anon/browser" "^0.6.0"
+    "@anon/proxy-types" "^0.6.0"
     "@browserbasehq/sdk" "^1.3.1"
     jose "^5.2.2"
     playwright "^1.43.1"

--- a/runtime-extension/package.json
+++ b/runtime-extension/package.json
@@ -10,7 +10,7 @@
     "package": "plasmo package --source-maps"
   },
   "dependencies": {
-    "@anon/sdk-browser-extension": "^0.6.0",
+    "@anon/sdk-browser-extension": "^0.7.0",
     "jose": "^5.2.4",
     "plasmo": "0.85.2",
     "react": "18.2.0",

--- a/runtime-extension/yarn.lock
+++ b/runtime-extension/yarn.lock
@@ -43,10 +43,10 @@
     node-fetch "^3.3.2"
     proxy-agent "^6.4.0"
 
-"@anon/sdk-browser-extension@^0.6.0":
-  version "0.6.0"
-  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/sdk-browser-extension/-/0.6.0/sdk-browser-extension-0.6.0.tgz#32f9d9f939e56faeaf82e1bea841737fad103a0e"
-  integrity sha512-r91WqfOqhDqTYmbkOBRHzV3HKTA1tRV/QYyHaldPEyAkDDd5WQxC5Q1va/+crE6BXDnI3Z8evkEr5gCT1NPs2A==
+"@anon/sdk-browser-extension@^0.7.0":
+  version "0.7.0"
+  resolved "https://npm.cloudsmith.io/anon/anon-sdk/@anon/sdk-browser-extension/-/0.7.0/sdk-browser-extension-0.7.0.tgz#8b44a02732c8c11b2127a356cbe140330d70e882"
+  integrity sha512-KODL8WaLFKyl0UcxrzIFUCPkT0K+OYB+4GNCzVUHTEzb2Fo70jUibRHE263N2hxAINaXxGFnA8lr/HxlIYcHng==
   dependencies:
     jose "^5.2.1"
 


### PR DESCRIPTION
# Bump Anon Package Versions

sdk-browser-extension -> 0.7.0
sdk-web-link-typescript -> 0.6.0
sdk-typescript -> 0.7.0
actions -> 0.2.0

> [!NOTE]
> @anon/sdk-react-native was not bumped
